### PR TITLE
Allow report_ui builds with explicit input/output paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,16 @@ cp <OUTPUT_DIR>/bridging_scores.csv src/report_ui/input/opinions.csv
 cp <OUTPUT_DIR>/report_text/report_data.json src/report_ui/input/summary.json
 ```
 
+Alternatively, skip the copy step and pass paths explicitly:
+
+```shell
+cd src/report_ui
+node build.js inline \
+  --bridging_scores <OUTPUT_DIR>/bridging_scores.csv \
+  --summary <OUTPUT_DIR>/report_text/report_data.json \
+  --output <OUTPUT_DIR>/report.html
+```
+
 ##### **Customize the Report (Optional)**:
 
 You can edit `src/report_ui/input/config.json` to customize the report. Key options include:

--- a/src/report_ui/README.md
+++ b/src/report_ui/README.md
@@ -59,6 +59,31 @@ All results are in the `output` folder ready to deploy or share. To preview:
 
 ---
 
+## Programmatic / CLI usage (optional)
+
+The copy-into-`input/` workflow above is unchanged. If your pipeline already has artefacts on disk, you can pass their paths directly instead of copying:
+
+```bash
+# Inline (single self-contained HTML) — use --output
+node build.js inline \
+  --bridging_scores /path/to/bridging_scores.csv \
+  --summary /path/to/report_data.json \
+  --output /path/to/report.html
+
+# Static (HTML + CSS/JS siblings) — use --outputDir
+node build.js static \
+  --opinions /path/to/opinions.csv \
+  --summary /path/to/report_data.json \
+  --outputDir /path/to/out
+# → /path/to/out/index.html plus assets
+```
+
+`--opinions` and `--bridging_scores` are aliases. Optional flags: `--inputDir`, `--config`, `--predicted`. Defaults still resolve under `./input` when flags are omitted.
+
+Using the wrong output flag for the mode fails with a clear error (`inline` forbids `--outputDir`; `static` forbids `--output`). With no path flags, behaviour matches the Quick start section (`output/static` / `output/inline`).
+
+---
+
 ## Configuration and input details
 
 ### `opinions.csv` Format

--- a/src/report_ui/bin/cli.js
+++ b/src/report_ui/bin/cli.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+/**
+ * Thin CLI wrapper around runBuild. Prefer `node build.js ...` when working
+ * inside this directory; the bin entry is for convenience when installed.
+ */
+import { runBuild } from "../build.js";
+
+runBuild(process.argv, process.cwd())
+  .then((result) => {
+    if (result.output) {
+      console.log(`Report written to: ${result.output}`);
+    } else if (result.outputDir) {
+      console.log(`Report written to: ${result.outputDir}`);
+    }
+  })
+  .catch((error) => {
+    console.error(error.message || error);
+    process.exit(1);
+  });

--- a/src/report_ui/build.js
+++ b/src/report_ui/build.js
@@ -4,12 +4,19 @@
  * data conversion (CSV to JSON), template rendering (Mustache), asset copying,
  * and deployment tasks.
  *
+ * Supports the historical copy-into-`input/` workflow and optional explicit
+ * input/output path flags (see resolveBuildOptions).
+ *
  * @module BuildScript
  */
 
 import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { processReportData, resolveBuildOptions } from "./data.js";
+
+const packageRoot = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Executes a shell command synchronously and captures the output.
@@ -26,6 +33,7 @@ const run = (cmd) => {
       stdio: "pipe",
       encoding: "utf-8",
       maxBuffer: 1024 * 1024 * 50, // 50MB buffer
+      cwd: packageRoot,
     });
   } catch (e) {
     console.error(`Error running: ${cmd}`);
@@ -42,7 +50,7 @@ const run = (cmd) => {
  */
 const runInherit = (cmd) => {
   try {
-    execSync(cmd, { stdio: "inherit" });
+    execSync(cmd, { stdio: "inherit", cwd: packageRoot });
   } catch (e) {
     process.exit(1);
   }
@@ -89,6 +97,58 @@ const cp = (src, dest) => {
 };
 
 /**
+ * Active build paths for the current run. Defaults match the historical layout.
+ * @type {{
+ *   inputDir: string,
+ *   workDir: string,
+ *   staticOutDir: string,
+ *   inlineOutFile: string,
+ *   opinionsCsv: string,
+ *   summaryPath: string|null,
+ *   configPath: string|null,
+ *   predictedPath: string|null,
+ *   useLegacyDataJs: boolean,
+ * }}
+ */
+let ctx = {
+  inputDir: path.join(packageRoot, "input"),
+  workDir: path.join(packageRoot, "temp"),
+  staticOutDir: path.join(packageRoot, "output", "static"),
+  inlineOutFile: path.join(packageRoot, "output", "inline", "index.html"),
+  opinionsCsv: path.join(packageRoot, "input", "opinions.csv"),
+  summaryPath: null,
+  configPath: null,
+  predictedPath: null,
+  useLegacyDataJs: true,
+};
+
+/**
+ * Relativize a path for shell commands executed with cwd=packageRoot.
+ * @param {string} absPath
+ * @returns {string}
+ */
+function rel(absPath) {
+  return path.relative(packageRoot, absPath) || ".";
+}
+
+/**
+ * Resets ctx to the historical default layout under packageRoot.
+ */
+function resetDefaultCtx() {
+  ctx = {
+    inputDir: path.join(packageRoot, "input"),
+    workDir: path.join(packageRoot, "temp"),
+    staticOutDir: path.join(packageRoot, "output", "static"),
+    inlineOutFile: path.join(packageRoot, "output", "inline", "index.html"),
+    opinionsCsv: path.join(packageRoot, "input", "opinions.csv"),
+    summaryPath: null,
+    configPath: null,
+    predictedPath: null,
+    useLegacyDataJs: true,
+  };
+}
+
+/**
  * Collection of build tasks available to the CLI.
  * @namespace
  */
@@ -99,26 +159,40 @@ const tasks = {
    */
   start: (dev) => {
     console.log("...preparing directory");
-    rm("temp");
-    mkdir("temp");
+    rm(ctx.workDir);
+    mkdir(ctx.workDir);
     if (!dev) {
-      rm("output");
-      mkdir("output");
+      const defaultOutput = path.join(packageRoot, "output");
+      const defaultStatic = path.join(defaultOutput, "static");
+      const defaultInline = path.join(defaultOutput, "inline", "index.html");
+      const usingDefaultStatic =
+        path.resolve(ctx.staticOutDir) === defaultStatic;
+      const usingDefaultInline =
+        path.resolve(ctx.inlineOutFile) === defaultInline;
+      // Only wipe the package output/ tree when writing into the default layout.
+      if (usingDefaultStatic && usingDefaultInline) {
+        rm(defaultOutput);
+        mkdir(defaultOutput);
+      } else if (usingDefaultStatic) {
+        rm(ctx.staticOutDir);
+      }
     }
   },
 
   /**
    * Converts input CSV data to JSON and runs the data processing script.
-   * Uses `csvtojson` for conversion and executes `data.js`.
+   * Uses `csvtojson` for conversion and executes `data.js` (legacy) or
+   * processReportData (explicit paths).
    */
   data: () => {
     console.log("...converting opinions csv to json and processing data");
-    const fileDescriptor = fs.openSync("temp/opinions.json", "w");
+    const opinionsJson = path.join(ctx.workDir, "opinions.json");
+    const fileDescriptor = fs.openSync(opinionsJson, "w");
 
     try {
-      // Stream output of csvtojson directly to the file descriptor
-      execSync(`npx -y -q csvtojson input/opinions.csv`, {
+      execSync(`npx -y -q csvtojson "${ctx.opinionsCsv}"`, {
         stdio: ["ignore", fileDescriptor, "inherit"],
+        cwd: packageRoot,
       });
     } catch (e) {
       console.error("Error converting CSV");
@@ -127,7 +201,34 @@ const tasks = {
       fs.closeSync(fileDescriptor);
     }
 
-    runInherit("node data.js");
+    if (ctx.useLegacyDataJs) {
+      runInherit("node data.js");
+      return;
+    }
+
+    const opinionsRaw = JSON.parse(fs.readFileSync(opinionsJson, "utf-8"));
+    const summaryPath =
+      ctx.summaryPath || path.join(ctx.inputDir, "summary.json");
+    const configPath =
+      ctx.configPath ||
+      (fs.existsSync(path.join(ctx.inputDir, "config.json"))
+        ? path.join(ctx.inputDir, "config.json")
+        : null);
+    const predictedPath =
+      ctx.predictedPath ||
+      (fs.existsSync(path.join(ctx.inputDir, "predicted.json"))
+        ? path.join(ctx.inputDir, "predicted.json")
+        : null);
+
+    processReportData({
+      opinionsRaw,
+      summaryPath,
+      configPath,
+      predictedPath,
+      inputDir: ctx.inputDir,
+      packageRoot,
+      workDir: ctx.workDir,
+    });
   },
 
   /**
@@ -137,9 +238,9 @@ const tasks = {
   htmlStatic: () => {
     console.log("...generating HTML (Static)");
     const html = run(
-      "npx -y -q mustache temp/data-static.json src/index.mustache",
+      `npx -y -q mustache "${rel(path.join(ctx.workDir, "data-static.json"))}" src/index.mustache`,
     );
-    fs.writeFileSync("temp/raw.html", html);
+    fs.writeFileSync(path.join(ctx.workDir, "raw.html"), html);
   },
 
   /**
@@ -149,9 +250,9 @@ const tasks = {
   htmlInline: () => {
     console.log("...generating HTML (Inline)");
     const html = run(
-      "npx -y -q mustache temp/data-inline.json src/index.mustache",
+      `npx -y -q mustache "${rel(path.join(ctx.workDir, "data-inline.json"))}" src/index.mustache`,
     );
-    fs.writeFileSync("temp/raw.html", html);
+    fs.writeFileSync(path.join(ctx.workDir, "raw.html"), html);
   },
 
   /**
@@ -160,31 +261,32 @@ const tasks = {
    */
   assets: () => {
     console.log("...copying assets");
-    mkdir("output/static");
+    mkdir(ctx.staticOutDir);
 
-    // Copy individual files from src/ to output/static/
-    if (fs.existsSync("src")) {
-      const srcFiles = fs.readdirSync("src");
+    const srcDir = path.join(packageRoot, "src");
+    if (fs.existsSync(srcDir)) {
+      const srcFiles = fs.readdirSync(srcDir);
       srcFiles.forEach((file) => {
-        cp(path.join("src", file), "output/static/");
+        cp(path.join(srcDir, file), ctx.staticOutDir);
       });
     }
 
-    cp("temp/quotes.json", "output/static/");
-    cp("temp/raw.html", "output/static/index.html");
+    cp(path.join(ctx.workDir, "quotes.json"), ctx.staticOutDir);
+    cp(
+      path.join(ctx.workDir, "raw.html"),
+      path.join(ctx.staticOutDir, "index.html"),
+    );
 
-    // Copy logo files from input/
-    if (fs.existsSync("input")) {
-      const inputFiles = fs.readdirSync("input");
+    if (fs.existsSync(ctx.inputDir)) {
+      const inputFiles = fs.readdirSync(ctx.inputDir);
       inputFiles
         .filter((f) => f.startsWith("logo."))
         .forEach((f) => {
-          cp(path.join("input", f), "output/static/");
+          cp(path.join(ctx.inputDir, f), ctx.staticOutDir);
         });
     }
 
-    // Cleanup artifacts
-    const mustacheFile = "output/static/index.mustache";
+    const mustacheFile = path.join(ctx.staticOutDir, "index.mustache");
     if (fs.existsSync(mustacheFile)) fs.rmSync(mustacheFile);
   },
 
@@ -195,57 +297,57 @@ const tasks = {
   inlineAssets: () => {
     console.log("...inlining data and assets");
 
-    mkdir("temp/svg");
+    mkdir(path.join(ctx.workDir, "svg"));
 
-    // copy everything recursively from src to temp (except index.mustache)
-    if (fs.existsSync("src")) {
-      const srcFiles = fs.readdirSync("src");
+    const srcDir = path.join(packageRoot, "src");
+    if (fs.existsSync(srcDir)) {
+      const srcFiles = fs.readdirSync(srcDir);
       srcFiles.forEach((file) => {
         if (file !== "index.mustache") {
-          cp(path.join("src", file), "temp");
+          cp(path.join(srcDir, file), ctx.workDir);
         }
       });
     }
 
-    // Copy logo files from input/
-    if (fs.existsSync("input")) {
-      const inputFiles = fs.readdirSync("input");
+    if (fs.existsSync(ctx.inputDir)) {
+      const inputFiles = fs.readdirSync(ctx.inputDir);
       inputFiles
         .filter((f) => f.startsWith("logo."))
         .forEach((f) => {
-          cp(path.join("input", f), "temp");
+          cp(path.join(ctx.inputDir, f), ctx.workDir);
         });
     }
 
-    mkdir("output/inline");
+    mkdir(path.dirname(ctx.inlineOutFile));
 
+    const rawRel = rel(path.join(ctx.workDir, "raw.html"));
+    const workRel = rel(ctx.workDir);
+    const tempIndex = path.join(ctx.workDir, "index.html");
     run(
-      "npx -y -q inline-source-cli --root temp temp/raw.html > temp/index.html",
+      `npx -y -q inline-source-cli --root "${workRel}" "${rawRel}" > "${rel(tempIndex)}"`,
     );
 
-    // Replace font file references with base64 data URIs
-    let html = fs.readFileSync("temp/index.html", "utf-8");
+    let html = fs.readFileSync(tempIndex, "utf-8");
 
-    if (fs.existsSync("temp/fonts")) {
+    const fontsDir = path.join(ctx.workDir, "fonts");
+    if (fs.existsSync(fontsDir)) {
       const fontFiles = fs
-        .readdirSync("temp/fonts")
+        .readdirSync(fontsDir)
         .filter((f) => f.endsWith(".woff2"));
       for (const fontFile of fontFiles) {
         const txtFile = path.join(
-          "temp/fonts",
+          fontsDir,
           fontFile.replace(/\.woff2$/, ".txt"),
         );
         if (!fs.existsSync(txtFile)) continue;
 
         const dataUri = fs.readFileSync(txtFile, "utf-8").trim();
         const fontUrl = `fonts/${fontFile}`;
-
-        // Replace all occurrences (single-quoted, double-quoted, or unquoted)
         html = html.split(fontUrl).join(dataUri);
       }
     }
 
-    fs.writeFileSync("output/inline/index.html", html);
+    fs.writeFileSync(ctx.inlineOutFile, html);
   },
 
   /**
@@ -253,17 +355,17 @@ const tasks = {
    */
   end: () => {
     console.log("...clean up");
-    rm("temp");
+    rm(ctx.workDir);
   },
 
   /**
    * Main Pipeline: Builds the project using the Static strategy.
    * Standard build with separate CSS/JS files.
    */
-  static: (test) => {
+  static: () => {
     console.log("\n** BUILDING REPORT (STATIC) **\n");
     tasks.start();
-    tasks.data(test);
+    tasks.data();
     tasks.htmlStatic();
     tasks.assets();
     tasks.end();
@@ -298,8 +400,9 @@ const tasks = {
    * Helper task for development; runs data conversion without full cleanup.
    */
   dev: () => {
+    resetDefaultCtx();
     tasks.start(true);
-    tasks.data(true);
+    tasks.data();
   },
 
   /**
@@ -307,19 +410,20 @@ const tasks = {
    * Intended for GitHub Pages deployment.
    */
   github: () => {
-    tasks.static(true);
+    resetDefaultCtx();
+    tasks.static();
     console.log("...deploying to github docs");
 
-    rm("docs");
-    mkdir("docs");
+    const docsDir = path.join(packageRoot, "docs");
+    rm(docsDir);
+    mkdir(docsDir);
 
-    const staticFiles = fs.readdirSync("output/static");
+    const staticFiles = fs.readdirSync(ctx.staticOutDir);
     staticFiles.forEach((file) => {
-      cp(path.join("output/static", file), "docs");
+      cp(path.join(ctx.staticOutDir, file), docsDir);
     });
 
-    // Create .nojekyll to bypass GitHub Pages Jekyll processing
-    fs.closeSync(fs.openSync("docs/.nojekyll", "w"));
+    fs.closeSync(fs.openSync(path.join(docsDir, ".nojekyll"), "w"));
 
     runInherit("git add -A");
     runInherit('git commit -m "update github pages"');
@@ -327,23 +431,177 @@ const tasks = {
   },
 };
 
+/**
+ * Stages caller-supplied input files into workDir/staged-input so logos and
+ * translations resolve next to config, matching the historical input/ layout.
+ *
+ * @param {ReturnType<typeof resolveBuildOptions>} options
+ * @param {string} workDir
+ * @returns {string} Path to the staged input directory.
+ */
+function stageExplicitInputs(options, workDir) {
+  const stagedInput = path.join(workDir, "staged-input");
+  mkdir(stagedInput);
+
+  fs.copyFileSync(
+    options.opinionsPath,
+    path.join(stagedInput, "opinions.csv"),
+  );
+  fs.copyFileSync(options.summaryPath, path.join(stagedInput, "summary.json"));
+
+  if (options.configPath) {
+    fs.copyFileSync(
+      options.configPath,
+      path.join(stagedInput, "config.json"),
+    );
+  }
+
+  if (options.predictedPath) {
+    fs.copyFileSync(
+      options.predictedPath,
+      path.join(stagedInput, "predicted.json"),
+    );
+  }
+
+  if (fs.existsSync(options.inputDir)) {
+    for (const name of fs.readdirSync(options.inputDir)) {
+      if (name.startsWith("logo.")) {
+        cp(path.join(options.inputDir, name), stagedInput);
+      }
+    }
+    const translations = path.join(options.inputDir, "translations.json");
+    if (fs.existsSync(translations)) {
+      cp(translations, stagedInput);
+    }
+    if (options.configPath && fs.existsSync(options.configPath)) {
+      const config = JSON.parse(fs.readFileSync(options.configPath, "utf-8"));
+      if (config.translations) {
+        const t1 = path.join(options.inputDir, config.translations);
+        const t2 = path.join(
+          options.inputDir,
+          `${config.translations}.json`,
+        );
+        if (fs.existsSync(t1)) cp(t1, stagedInput);
+        else if (fs.existsSync(t2)) cp(t2, stagedInput);
+      }
+    }
+  }
+
+  return stagedInput;
+}
+
+/**
+ * Runs a report build from argv.
+ *
+ * @param {string[]} [argv=process.argv]
+ * @param {string} [cwd=process.cwd()]
+ * @returns {Promise<{output?: string, outputDir?: string}>}
+ */
+export async function runBuild(argv = process.argv, cwd = process.cwd()) {
+  const options = resolveBuildOptions(argv, cwd);
+  const command = options.command;
+
+  if (command === "preview") {
+    tasks.preview();
+    return {};
+  }
+  if (command === "dev") {
+    tasks.dev();
+    return {};
+  }
+  if (command === "github") {
+    tasks.github();
+    return {};
+  }
+
+  if (!["static", "inline", "build"].includes(command)) {
+    if (tasks[command]) {
+      tasks[command]();
+      return {};
+    }
+    throw new Error(`Unknown command: ${command}`);
+  }
+
+  const mode = options.effectiveMode;
+  const useExplicit =
+    options.hasExplicitInputPaths || options.hasExplicitOutputPaths;
+
+  if (!useExplicit) {
+    resetDefaultCtx();
+    if (mode === "inline") {
+      tasks.inline();
+      return { output: ctx.inlineOutFile };
+    }
+    tasks.static();
+    return { outputDir: ctx.staticOutDir };
+  }
+
+  // Explicit paths: prepare workDir, stage inputs, then run the same npx steps.
+  const workDir = path.join(packageRoot, "temp");
+  ctx = {
+    inputDir: path.join(workDir, "staged-input"),
+    workDir,
+    staticOutDir:
+      mode === "static"
+        ? options.outputDir
+        : path.join(packageRoot, "output", "static"),
+    inlineOutFile:
+      mode === "inline"
+        ? options.output
+        : path.join(packageRoot, "output", "inline", "index.html"),
+    opinionsCsv: path.join(workDir, "staged-input", "opinions.csv"),
+    summaryPath: null,
+    configPath: null,
+    predictedPath: null,
+    useLegacyDataJs: false,
+  };
+
+  if (mode === "inline") {
+    console.log("\n** BUILDING REPORT (INLINE) **\n");
+  } else {
+    console.log("\n** BUILDING REPORT (STATIC) **\n");
+  }
+
+  tasks.start();
+  console.log("...staging inputs");
+  const stagedInput = stageExplicitInputs(options, workDir);
+  ctx.inputDir = stagedInput;
+  ctx.opinionsCsv = path.join(stagedInput, "opinions.csv");
+  ctx.summaryPath = path.join(stagedInput, "summary.json");
+  ctx.configPath = fs.existsSync(path.join(stagedInput, "config.json"))
+    ? path.join(stagedInput, "config.json")
+    : null;
+  ctx.predictedPath = fs.existsSync(path.join(stagedInput, "predicted.json"))
+    ? path.join(stagedInput, "predicted.json")
+    : null;
+
+  tasks.data();
+  if (mode === "inline") {
+    tasks.htmlInline();
+    tasks.inlineAssets();
+    tasks.end();
+    console.log("\n** BUILD COMPLETE! **\n");
+    return { output: ctx.inlineOutFile };
+  }
+
+  tasks.htmlStatic();
+  tasks.assets();
+  tasks.end();
+  console.log("\n** BUILD COMPLETE! **\n");
+  return { outputDir: ctx.staticOutDir };
+}
+
 // -----------------------------------------------------------------------------
 // CLI Argument Parsing
 // -----------------------------------------------------------------------------
 
-const args = process.argv.slice(2);
-const command = args[0] || "static";
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
 
-if (command === "build") {
-  // Alias 'build' to 'inline'
-  tasks.inline();
-} else if (command === "static") {
-  tasks.static();
-} else if (command === "inline") {
-  tasks.inline();
-} else if (tasks[command]) {
-  // Run any specific task by name
-  tasks[command]();
-} else {
-  console.log(`Unknown command: ${command}`);
+if (isMain) {
+  runBuild(process.argv, process.cwd()).catch((error) => {
+    console.error(error.message || error);
+    process.exit(1);
+  });
 }

--- a/src/report_ui/data.js
+++ b/src/report_ui/data.js
@@ -8,6 +8,8 @@
  */
 
 import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
 
 const demographics_prefix = "demo:";
 /**
@@ -19,33 +21,176 @@ const demographics_prefix = "demo:";
  * @property {string|number} [AVERAGE_OF_2_BRIDGING] - Used for sorting.
  */
 
-// --- Data Loading ---
+/**
+ * Parses `--flag value` and `--flag=value` tokens from argv (after the command).
+ * @param {string[]} args
+ * @returns {Map<string, string>}
+ */
+function parseFlags(args) {
+  const flags = new Map();
+  for (let i = 0; i < args.length; i++) {
+    const token = args[i];
+    if (!token.startsWith("--")) continue;
+    const eq = token.indexOf("=");
+    if (eq !== -1) {
+      flags.set(token.slice(2, eq), token.slice(eq + 1));
+      continue;
+    }
+    const key = token.slice(2);
+    const next = args[i + 1];
+    if (next && !next.startsWith("--")) {
+      flags.set(key, next);
+      i++;
+    } else {
+      flags.set(key, "");
+    }
+  }
+  return flags;
+}
 
 /**
- * Raw opinions data source.
- * @type {RawOpinion[]}
+ * Resolves CLI build options from argv.
+ * Defaults match the historical copy-into-`input/` workflow.
+ *
+ * @param {string[]} [argv=process.argv]
+ * @param {string} [cwd=process.cwd()]
+ * @returns {Object} Resolved build options.
  */
-const opinions = JSON.parse(
-  fs.readFileSync("./temp/opinions.json", "utf-8"),
-).map((d, index) => ({
-  ...d,
-  index,
-}));
+export function resolveBuildOptions(argv = process.argv, cwd = process.cwd()) {
+  const args = argv.slice(2);
+  let commandToken = args[0] && !args[0].startsWith("--") ? args[0] : null;
+  if (!commandToken) {
+    commandToken = "static";
+  }
 
-const config = JSON.parse(
-  fs.readFileSync("./input/config.json", "utf-8"),
-);
+  const buildCommands = new Set(["static", "inline", "build"]);
+  const isBuildCommand = buildCommands.has(commandToken);
 
-const summary = JSON.parse(
-  fs.readFileSync("./input/summary.json", "utf-8"),
-);
+  const flags = parseFlags(args);
+  const hasOutput = flags.has("output");
+  const hasOutputDir = flags.has("outputDir");
 
-const predictedPath = "./input/predicted.json";
-const predictedRaw = fs.existsSync(predictedPath)
-  ? JSON.parse(fs.readFileSync(predictedPath, "utf-8"))
-  : [];
+  if (hasOutput && hasOutputDir) {
+    throw new Error(
+      "Use either --output (inline) or --outputDir (static), not both.",
+    );
+  }
 
-// --- Localization (i18n) Setup ---
+  let output = null;
+  let outputDir = null;
+  const effectiveMode =
+    commandToken === "build" ? "inline" : commandToken;
+
+  if (isBuildCommand) {
+    if (effectiveMode === "inline") {
+      if (hasOutputDir) {
+        throw new Error(
+          "inline mode writes a single HTML file; use --output <file.html> (not --outputDir).",
+        );
+      }
+      output = path.resolve(
+        cwd,
+        flags.get("output") || "output/inline/index.html",
+      );
+    } else if (effectiveMode === "static") {
+      if (hasOutput) {
+        throw new Error(
+          "static mode writes multiple artefacts; use --outputDir <dir> (not --output).",
+        );
+      }
+      outputDir = path.resolve(
+        cwd,
+        flags.get("outputDir") || "output/static",
+      );
+    }
+  }
+
+  const inputDir = path.resolve(cwd, flags.get("inputDir") || "input");
+
+  const opinionsFlag = flags.get("opinions");
+  const bridgingFlag = flags.get("bridging_scores");
+  if (opinionsFlag && bridgingFlag) {
+    const opinionsResolved = path.resolve(cwd, opinionsFlag);
+    const bridgingResolved = path.resolve(cwd, bridgingFlag);
+    if (opinionsResolved !== bridgingResolved) {
+      throw new Error(
+        "--opinions and --bridging_scores both set to different paths; use only one.",
+      );
+    }
+  }
+  const opinionsPath = path.resolve(
+    cwd,
+    opinionsFlag || bridgingFlag || path.join(inputDir, "opinions.csv"),
+  );
+  const summaryPath = path.resolve(
+    cwd,
+    flags.get("summary") || path.join(inputDir, "summary.json"),
+  );
+
+  const predictedExplicit = flags.has("predicted");
+  const configExplicit = flags.has("config");
+
+  let predictedPath = null;
+  if (predictedExplicit) {
+    predictedPath = path.resolve(cwd, flags.get("predicted"));
+  } else {
+    const defaultPredicted = path.join(inputDir, "predicted.json");
+    if (fs.existsSync(defaultPredicted)) {
+      predictedPath = defaultPredicted;
+    }
+  }
+
+  let configPath = null;
+  if (configExplicit) {
+    configPath = path.resolve(cwd, flags.get("config"));
+  } else {
+    const defaultConfig = path.join(inputDir, "config.json");
+    if (fs.existsSync(defaultConfig)) {
+      configPath = defaultConfig;
+    }
+  }
+
+  const hasExplicitInputPaths = Boolean(
+    flags.has("inputDir") ||
+      opinionsFlag ||
+      bridgingFlag ||
+      flags.has("summary") ||
+      predictedExplicit ||
+      configExplicit,
+  );
+  const hasExplicitOutputPaths = hasOutput || hasOutputDir;
+
+  if (isBuildCommand) {
+    if (!fs.existsSync(opinionsPath)) {
+      throw new Error(`Opinions CSV not found: ${opinionsPath}`);
+    }
+    if (!fs.existsSync(summaryPath)) {
+      throw new Error(`Summary JSON not found: ${summaryPath}`);
+    }
+    if (predictedExplicit && !fs.existsSync(predictedPath)) {
+      throw new Error(`Predicted JSON not found: ${predictedPath}`);
+    }
+    if (configExplicit && !fs.existsSync(configPath)) {
+      throw new Error(`Config JSON not found: ${configPath}`);
+    }
+  }
+
+  return {
+    command: commandToken,
+    effectiveMode: isBuildCommand ? effectiveMode : commandToken,
+    inputDir,
+    output,
+    outputDir,
+    opinionsPath,
+    summaryPath,
+    predictedPath,
+    configPath,
+    predictedExplicit,
+    configExplicit,
+    hasExplicitInputPaths,
+    hasExplicitOutputPaths,
+  };
+}
 
 /**
  * Recursively deep merges source object into target object.
@@ -70,533 +215,622 @@ function deepMerge(target, source) {
   return output;
 }
 
-const defaultI18n = JSON.parse(
-  fs.readFileSync("./src/default-translations.json", "utf-8"),
-);
+/**
+ * Processes report inputs into static/inline Mustache payloads and writes
+ * workDir JSON artefacts (quotes.json, data-static.json, data-inline.json).
+ *
+ * @param {Object} params
+ * @param {RawOpinion[]} params.opinionsRaw
+ * @param {string} params.summaryPath
+ * @param {string|null} [params.configPath]
+ * @param {string|null} [params.predictedPath]
+ * @param {string} params.inputDir - Dir for translations / relative logo paths.
+ * @param {string} params.packageRoot - Package root (for default-translations).
+ * @param {string} params.workDir - Directory to write quotes + data JSON files.
+ * @returns {{ dataStatic: Object, dataInline: Object, quotes: Object[] }}
+ */
+export function processReportData({
+  opinionsRaw,
+  summaryPath,
+  configPath = null,
+  predictedPath = null,
+  inputDir,
+  packageRoot,
+  workDir,
+}) {
+  const opinions = opinionsRaw.map((d, index) => ({
+    ...d,
+    index,
+  }));
 
-const userI18nPath = (() => {
-  if (config.translations) {
-    if (fs.existsSync(`./input/${config.translations}`)) {
-      return `./input/${config.translations}`;
+  const config = configPath
+    ? JSON.parse(fs.readFileSync(configPath, "utf-8"))
+    : {};
+
+  const summary = JSON.parse(fs.readFileSync(summaryPath, "utf-8"));
+
+  const predictedRaw =
+    predictedPath && fs.existsSync(predictedPath)
+      ? JSON.parse(fs.readFileSync(predictedPath, "utf-8"))
+      : [];
+
+  const defaultI18n = JSON.parse(
+    fs.readFileSync(
+      path.join(packageRoot, "src", "default-translations.json"),
+      "utf-8",
+    ),
+  );
+
+  const userI18nPath = (() => {
+    if (config.translations) {
+      const direct = path.join(inputDir, config.translations);
+      if (fs.existsSync(direct)) return direct;
+      const withJson = path.join(inputDir, `${config.translations}.json`);
+      if (fs.existsSync(withJson)) return withJson;
     }
-    if (fs.existsSync(`./input/${config.translations}.json`)) {
-      return `./input/${config.translations}.json`;
-    }
-  }
-  if (fs.existsSync("./input/translations.json")) {
-    return "./input/translations.json";
-  }
-  return null;
-})();
+    const defaultPath = path.join(inputDir, "translations.json");
+    if (fs.existsSync(defaultPath)) return defaultPath;
+    return null;
+  })();
 
-const userI18n = userI18nPath
-  ? JSON.parse(fs.readFileSync(userI18nPath, "utf-8"))
-  : {};
+  const userI18n = userI18nPath
+    ? JSON.parse(fs.readFileSync(userI18nPath, "utf-8"))
+    : {};
 
-const i18n = deepMerge(defaultI18n, userI18n);
-i18n.locale = i18n.locale || "en";
-i18n.direction = i18n.direction || "ltr";
+  const i18n = deepMerge(defaultI18n, userI18n);
+  i18n.locale = i18n.locale || "en";
+  i18n.direction = i18n.direction || "ltr";
 
-const numberFormatter = new Intl.NumberFormat(i18n.locale);
-const percentFormatter = new Intl.NumberFormat(i18n.locale, {
-  style: "percent",
-  maximumFractionDigits: 1,
-});
-
-/**
- * Formats a value as a localized percentage string.
- * @param {number|string} value
- * @returns {string|null}
- */
-function formatPercent(value) {
-  if (value == null || value === "") return null;
-  const num = Number(value);
-  if (isNaN(num)) return null;
-  const ratio = num > 1 ? num / 100 : num;
-  return percentFormatter.format(ratio);
-}
-
-const overviewChart = config.overview_chart || "toggle";
-const options = {
-  logo: config.logo || "",
-  overviewChart,
-  hasToggle: overviewChart === "toggle",
-  lowSampleThreshold: config.low_sample_warning_threshold || 30,
-  sampleQuoteCount: Math.min(
-    Math.max(config.number_of_sample_quotes || 4, 2),
-    10,
-  ), // between 2 and 10 sample quotes per opinion
-  topOpinionCount: Math.min(
-    Math.max(config.number_of_top_opinions || 10, 2),
-    20,
-  ), // between 2 and 20 top opinions
-  topicColors: config.chart_colors || [
-    "#AFB42B",
-    "#F4511E",
-    "#3949AB",
-    "#E52592",
-    "#00897B",
-    "#EFB22F",
-    "#aaa",
-  ],
-  demographicColors: config.demographic_colors || [
-    "#4886f7",
-    "#4071d5",
-    "#385db3",
-    "#2f4a93",
-    "#273874",
-    "#1e2656",
-  ],
-};
-// --- Helper Functions ---
-
-/**
- * Converts a string of markdown to clean HTML.
- * @param {string} text
- * @returns {string}
- */
-function cleanMarkdown(text) {
-  if (!text) return "";
-  let html = text;
-
-  html = html.replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>");
-  html = html.replace(/\*(.*?)\*/g, "<em>$1</em>");
-
-  return html;
-}
-
-/**
- * Strips markdown header symbols (e.g. '#', '##') and leading whitespace.
- * @param {string} text
- * @returns {string}
- */
-function stripMarkdownHeader(text) {
-  if (!text) return "";
-  return text.replace(/^#+\s*/, "");
-}
-
-/**
- * Sums an array of numbers.
- * @param {number[]} arr
- * @returns {number}
- */
-function sum(arr) {
-  return arr.reduce((a, b) => a + b, 0);
-}
-
-/**
- * Formats a number according to the active locale.
- * @param {number} num
- * @returns {string}
- */
-function formatNumber(num) {
-  return numberFormatter.format(num);
-}
-
-/**
- * Groups an array of objects by a specific property key.
- * @param {Object[]} array - The array to group.
- * @param {string} column - The key to group by.
- * @returns {[string, Object[]][]} An array of [key, value[]] pairs.
- */
-function groupBy(array, column) {
-  const map = new Map();
-
-  array.forEach((item) => {
-    const key = item[column];
-    if (!map.has(key)) map.set(key, []);
-    map.get(key).push(item);
+  const numberFormatter = new Intl.NumberFormat(i18n.locale);
+  const percentFormatter = new Intl.NumberFormat(i18n.locale, {
+    style: "percent",
+    maximumFractionDigits: 1,
   });
 
-  return Array.from(map);
-}
+  /**
+   * Formats a value as a localized percentage string.
+   * @param {number|string} value
+   * @returns {string|null}
+   */
+  function formatPercent(value) {
+    if (value == null || value === "") return null;
+    const num = Number(value);
+    if (isNaN(num)) return null;
+    const ratio = num > 1 ? num / 100 : num;
+    return percentFormatter.format(ratio);
+  }
 
-/**
- * Generates a URL-safe slug from a string supporting all Unicode scripts.
- * @param {string} str - The input string.
- * @param {boolean} [useFirstWords=false] - If true, limits the slug to the first 5 words.
- * @returns {string} A lowercase, alphanumeric slug.
- */
-function generateId(str, useFirstWords = false) {
-  if (!str) return "item";
-  const words = str
-    .split(" ")
-    .slice(0, useFirstWords ? 5 : undefined)
-    .join(" ");
-  return (
-    words
-      .toLowerCase()
-      .normalize("NFD")
-      .replace(/[\u0300-\u036f]/g, "") // Strip diacritics where applicable
-      .replace(/[^\p{L}\p{N}]+/gu, "") || "item"
-  );
-}
+  const overviewChart = config.overview_chart || "toggle";
+  const options = {
+    logo: config.logo || "",
+    overviewChart,
+    hasToggle: overviewChart === "toggle",
+    lowSampleThreshold: config.low_sample_warning_threshold || 30,
+    sampleQuoteCount: Math.min(
+      Math.max(config.number_of_sample_quotes || 4, 2),
+      10,
+    ), // between 2 and 10 sample quotes per opinion
+    topOpinionCount: Math.min(
+      Math.max(config.number_of_top_opinions || 10, 2),
+      20,
+    ), // between 2 and 20 top opinions
+    topicColors: config.chart_colors || [
+      "#AFB42B",
+      "#F4511E",
+      "#3949AB",
+      "#E52592",
+      "#00897B",
+      "#EFB22F",
+      "#aaa",
+    ],
+    demographicColors: config.demographic_colors || [
+      "#4886f7",
+      "#4071d5",
+      "#385db3",
+      "#2f4a93",
+      "#273874",
+      "#1e2656",
+    ],
+  };
 
-/**
- * Extracts quotes from raw values, cleans them, and sorts them by bridging score.
- * @param {RawOpinion[]} values
- * @returns {Object[]} Sorted quotes with text, participant_id, and bridging score.
- */
-function sortAndExtractQuotes(values) {
-  return (
-    values
-      .map((v) => {
-        const demos = Object.fromEntries(
-          Object.entries(v)
-            .filter(([k]) => k.startsWith(demographics_prefix))
-            .map(([k, val]) => [k.slice(demographics_prefix.length), val]),
-        );
-        return {
-          index: v.index,
-          text: v.quote,
-          participant_id: v.participant_id,
-          avg_bridging: v.AVERAGE_OF_2_BRIDGING ? +v.AVERAGE_OF_2_BRIDGING : 0,
-          ...demos,
-        };
-      })
-      // Sort descending by bridging score (highest first)
-      .sort((a, b) => b.avg_bridging - a.avg_bridging)
-      .filter((v) => v.text)
-  );
-}
+  /**
+   * Converts a string of markdown to clean HTML.
+   * @param {string} text
+   * @returns {string}
+   */
+  function cleanMarkdown(text) {
+    if (!text) return "";
+    let html = text;
 
-/**
- * Transforms the flat raw opinions list into a hierarchical structure:
- * Topic -> Opinions -> Quotes.
- * Matches topics with summary data and generates unique IDs.
- *
- * @param {RawOpinion[]} opinions
- * @returns {Object[]} Structured topic objects.
- */
-function groupOpinions(opinions) {
-  // 1. Group by high-level Topic
-  const byTopic = groupBy(opinions, "topic");
+    html = html.replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>");
+    html = html.replace(/\*(.*?)\*/g, "<em>$1</em>");
 
-  const o = byTopic.map(([topicText, topicOpinions]) => {
-    // 2. Find matching AI summary (stripping markdown headers)
-    const topicMatch = summary.sub_contents.find(
-      (t) => stripMarkdownHeader(t.title) === topicText,
-    );
+    return html;
+  }
 
-    const topicId = generateId(topicText, true);
+  /**
+   * Strips markdown header symbols (e.g. '#', '##') and leading whitespace.
+   * @param {string} text
+   * @returns {string}
+   */
+  function stripMarkdownHeader(text) {
+    if (!text) return "";
+    return text.replace(/^#+\s*/, "");
+  }
 
-    // 3. Group by specific Opinion within the Topic
-    const byOpinion = groupBy(topicOpinions, "opinion").map(([_, values]) => ({
-      opinionID: generateId(values[0].opinion),
-      // fullID is crucial: it links the UI chart to the specific quotes list
-      fullID: `${topicId}-${generateId(values[0].opinion)}`,
-      text: values[0].opinion,
-      count: values.length,
-      quotes: sortAndExtractQuotes(values),
-    }));
+  /**
+   * Sums an array of numbers.
+   * @param {number[]} arr
+   * @returns {number}
+   */
+  function sum(arr) {
+    return arr.reduce((a, b) => a + b, 0);
+  }
 
-    // 4. Sort opinions: "Other" always last, otherwise by count descending
-    byOpinion.sort((a, b) => {
-      if (a.text === "Other") return 1;
-      if (b.text === "Other") return -1;
-      return b.count - a.count;
+  /**
+   * Formats a number according to the active locale.
+   * @param {number} num
+   * @returns {string}
+   */
+  function formatNumber(num) {
+    return numberFormatter.format(num);
+  }
+
+  /**
+   * Groups an array of objects by a specific property key.
+   * @param {Object[]} array - The array to group.
+   * @param {string} column - The key to group by.
+   * @returns {[string, Object[]][]} An array of [key, value[]] pairs.
+   */
+  function groupBy(array, column) {
+    const map = new Map();
+
+    array.forEach((item) => {
+      const key = item[column];
+      if (!map.has(key)) map.set(key, []);
+      map.get(key).push(item);
     });
 
-    return {
-      topicID: topicId,
-      summary: cleanMarkdown(topicMatch?.text),
-      text: topicText,
-      count: topicOpinions.length,
-      opinions: byOpinion,
-    };
-  });
+    return Array.from(map);
+  }
 
-  return o;
-}
+  /**
+   * Generates a URL-safe slug from a string supporting all Unicode scripts.
+   * @param {string} str - The input string.
+   * @param {boolean} [useFirstWords=false] - If true, limits the slug to the first 5 words.
+   * @returns {string} A lowercase, alphanumeric slug.
+   */
+  function generateId(str, useFirstWords = false) {
+    if (!str) return "item";
+    const words = str
+      .split(" ")
+      .slice(0, useFirstWords ? 5 : undefined)
+      .join(" ");
+    return (
+      words
+        .toLowerCase()
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "") // Strip diacritics where applicable
+        .replace(/[^\p{L}\p{N}]+/gu, "") || "item"
+    );
+  }
 
-/**
- * Creates a flat lookup list of all quotes.
- * Used for the 'quotes.json' file (lazy loading).
- * @param {Object[]} opinionsGrouped - The structured topic hierarchy.
- * @returns {Object[]} Array of { id: string, quote: string }
- */
-function flattenQuotes(opinionsGrouped) {
-  const flat = [];
-  opinionsGrouped.forEach((topic) => {
-    topic.opinions.forEach((opinion, i) => {
-      opinion.quotes.forEach((quote) => {
-        const { index, text, participant_id, avg_bridging, fullID, ...demos } = quote;
-        flat.push({
-          id: opinion.fullID,
-          quote: quote.text,
-          ...demos,
+  /**
+   * Extracts quotes from raw values, cleans them, and sorts them by bridging score.
+   * @param {RawOpinion[]} values
+   * @returns {Object[]} Sorted quotes with text, participant_id, and bridging score.
+   */
+  function sortAndExtractQuotes(values) {
+    return (
+      values
+        .map((v) => {
+          const demos = Object.fromEntries(
+            Object.entries(v)
+              .filter(([k]) => k.startsWith(demographics_prefix))
+              .map(([k, val]) => [k.slice(demographics_prefix.length), val]),
+          );
+          return {
+            index: v.index,
+            text: v.quote,
+            participant_id: v.participant_id,
+            avg_bridging: v.AVERAGE_OF_2_BRIDGING
+              ? +v.AVERAGE_OF_2_BRIDGING
+              : 0,
+            ...demos,
+          };
+        })
+        // Sort descending by bridging score (highest first)
+        .sort((a, b) => b.avg_bridging - a.avg_bridging)
+        .filter((v) => v.text)
+    );
+  }
+
+  /**
+   * Transforms the flat raw opinions list into a hierarchical structure:
+   * Topic -> Opinions -> Quotes.
+   * Matches topics with summary data and generates unique IDs.
+   *
+   * @param {RawOpinion[]} opinionsList
+   * @returns {Object[]} Structured topic objects.
+   */
+  function groupOpinions(opinionsList) {
+    // 1. Group by high-level Topic
+    const byTopic = groupBy(opinionsList, "topic");
+
+    const o = byTopic.map(([topicText, topicOpinions]) => {
+      // 2. Find matching AI summary (stripping markdown headers)
+      const topicMatch = summary.sub_contents.find(
+        (t) => stripMarkdownHeader(t.title) === topicText,
+      );
+
+      const topicId = generateId(topicText, true);
+
+      // 3. Group by specific Opinion within the Topic
+      const byOpinion = groupBy(topicOpinions, "opinion").map(
+        ([_, values]) => ({
+          opinionID: generateId(values[0].opinion),
+          // fullID is crucial: it links the UI chart to the specific quotes list
+          fullID: `${topicId}-${generateId(values[0].opinion)}`,
+          text: values[0].opinion,
+          count: values.length,
+          quotes: sortAndExtractQuotes(values),
+        }),
+      );
+
+      // 4. Sort opinions: "Other" always last, otherwise by count descending
+      byOpinion.sort((a, b) => {
+        if (a.text === "Other") return 1;
+        if (b.text === "Other") return -1;
+        return b.count - a.count;
+      });
+
+      return {
+        topicID: topicId,
+        summary: cleanMarkdown(topicMatch?.text),
+        text: topicText,
+        count: topicOpinions.length,
+        opinions: byOpinion,
+      };
+    });
+
+    return o;
+  }
+
+  /**
+   * Creates a flat lookup list of all quotes.
+   * Used for the 'quotes.json' file (lazy loading).
+   * @param {Object[]} opinionsGrouped - The structured topic hierarchy.
+   * @returns {Object[]} Array of { id: string, quote: string }
+   */
+  function flattenQuotes(opinionsGrouped) {
+    const flat = [];
+    opinionsGrouped.forEach((topic) => {
+      topic.opinions.forEach((opinion, i) => {
+        opinion.quotes.forEach((quote) => {
+          const {
+            index,
+            text,
+            participant_id,
+            avg_bridging,
+            fullID,
+            ...demos
+          } = quote;
+          flat.push({
+            id: opinion.fullID,
+            quote: quote.text,
+            ...demos,
+          });
         });
       });
     });
-  });
-  return flat;
-}
+    return flat;
+  }
 
-/**
- * Splits summary text into paragraphs based on double newlines.
- * @param {string} text
- * @returns {string[]} Array of paragraph strings.
- */
-function parseSummary(text) {
-  return text.split("\n\n").map((p) => p.trim());
-}
+  /**
+   * Splits summary text into paragraphs based on double newlines.
+   * @param {string} text
+   * @returns {string[]} Array of paragraph strings.
+   */
+  function parseSummary(text) {
+    return text.split("\n\n").map((p) => p.trim());
+  }
 
-// --- Sample Selection Logic ---
+  /**
+   * A global set to track participants included in sample previews.
+   * Used to ensure diversity in the sample quotes.
+   * @type {Set<string>}
+   */
+  const globalSampleParticipants = new Set();
 
-/**
- * A global set to track participants included in sample previews.
- * Used to ensure diversity in the sample quotes.
- * @type {Set<string>}
- */
-const globalSampleParticipants = new Set();
+  /**
+   * Selects a small subset of quotes for the sample quotes.
+   * Attempts to prioritize participants (Participant IDs) who haven't been featured yet
+   * to maximize the diversity of voices shown in the initial view.
+   *
+   * @param {Object[]} topicOpinions - The opinions (with quotes) for a topic.
+   * @returns {Object[]} An array of selected quote objects.
+   */
+  function getSampleQuotes(topicOpinions) {
+    // add opinion fulID to quote objects for easier lookup
+    const allQuotes = topicOpinions
+      .map((o) => o.quotes.map((q) => ({ ...q, fullID: o.fullID })))
+      .flat();
 
-/**
- * Selects a small subset of quotes for the sample quotes.
- * Attempts to prioritize participants (Participant IDs) who haven't been featured yet
- * to maximize the diversity of voices shown in the initial view.
- *
- * @param {Object[]} quotes - The full list of quotes for an opinion.
- * @returns {string[]} An array of selected quote texts.
- */
-function getSampleQuotes(opinions) {
-  // add opinion fulID to quote objects for easier lookup
-  const allQuotes = opinions
-    .map((o) => o.quotes.map((q) => ({ ...q, fullID: o.fullID })))
-    .flat();
+    // sort all quotes by avg_bridging (descending) to prioritize more "representative" quotes in the sample
+    allQuotes.sort((a, b) => b.avg_bridging - a.avg_bridging);
 
-  // sort all quotes by avg_bridging (descending) to prioritize more "representative" quotes in the sample
-  allQuotes.sort((a, b) => b.avg_bridging - a.avg_bridging);
+    // loop through each opinion, and "draft" a sample quote, prioritizing quotes from participants we haven't featured yet in the globalSampleParticipants set, until we hit our options.sampleQuoteCount limit for the opinion. This way we maximize the diversity of voices shown in the sample quotes across opinions, while still prioritizing the most "representative" quotes based on bridging score.
 
-  // loop through each opinion, and "draft" a sample quote, prioritizing quotes from participants we haven't featured yet in the globalSampleParticipants set, until we hit our options.sampleQuoteCount limit for the opinion. This way we maximize the diversity of voices shown in the sample quotes across opinions, while still prioritizing the most "representative" quotes based on bridging score.
-
-  const selected = [];
-  // loop through the number of quotes we want to show in the sample
-  for (let i = 0; i < options.sampleQuoteCount; i++) {
-    // Loop through the sorted quotes and find the first quote whose
-    // participant (Participant ID) hasn't been featured yet in the
-    // globalSampleParticipants set.
-    // loop through each opinion
-    for (let o of opinions) {
-      const possible = allQuotes.filter((q) => q.fullID === o.fullID);
-      if (!possible.length) continue;
-      // find the first quote in this opinion from a participant we haven't featured at all yet
-      let newQuote = possible.find(
-        (q) =>
-          !globalSampleParticipants.has(q.participant_id) &&
-          !selected.find((s) => s.participant_id === q.participant_id),
-      );
-      // now try someone that hasn't been featured in this opinion's sample yet, even if they have been featured in other opinions' samples
-      if (!newQuote) {
-        newQuote = possible.find((q) => !selected.find((s) => s.participant_id === q.participant_id));
-      }
-
-      // now try someone that has already been featured in this same topic
-      if (!newQuote)
-        newQuote = possible.find(
-          (q) => !selected.find((s) => s.index === q.index),
+    const selected = [];
+    // loop through the number of quotes we want to show in the sample
+    for (let i = 0; i < options.sampleQuoteCount; i++) {
+      // Loop through the sorted quotes and find the first quote whose
+      // participant (Participant ID) hasn't been featured yet in the
+      // globalSampleParticipants set.
+      // loop through each opinion
+      for (let o of topicOpinions) {
+        const possible = allQuotes.filter((q) => q.fullID === o.fullID);
+        if (!possible.length) continue;
+        // find the first quote in this opinion from a participant we haven't featured at all yet
+        let newQuote = possible.find(
+          (q) =>
+            !globalSampleParticipants.has(q.participant_id) &&
+            !selected.find((s) => s.participant_id === q.participant_id),
         );
+        // now try someone that hasn't been featured in this opinion's sample yet, even if they have been featured in other opinions' samples
+        if (!newQuote) {
+          newQuote = possible.find(
+            (q) => !selected.find((s) => s.participant_id === q.participant_id),
+          );
+        }
 
-      if (newQuote) {
-        selected.push({ ...newQuote });
-        globalSampleParticipants.add(newQuote.participant_id);
+        // now try someone that has already been featured in this same topic
+        if (!newQuote)
+          newQuote = possible.find(
+            (q) => !selected.find((s) => s.index === q.index),
+          );
+
+        if (newQuote) {
+          selected.push({ ...newQuote });
+          globalSampleParticipants.add(newQuote.participant_id);
+        }
       }
     }
+
+    // now selected should have up to opinions * options.sampleQuoteCount quotes
+    return selected;
   }
 
-  // now selected should have up to opinions * options.sampleQuoteCount quotes
-  return selected;
-}
-
-/**
- * Counts the number of unique participants (Participant IDs) in a list of opinions.
- * @param {Object[]} opinions
- * @returns {number} Unique participant count.
- */
-function getUniqueQuoteCount(opinions) {
-  const uniqueParticipantIds = new Set();
-  opinions.forEach((o) => {
-    o.quotes.forEach((q) => {
-      uniqueParticipantIds.add(q.participant_id);
+  /**
+   * Counts the number of unique participants (Participant IDs) in a list of opinions.
+   * @param {Object[]} topicOpinions
+   * @returns {number} Unique participant count.
+   */
+  function getUniqueQuoteCount(topicOpinions) {
+    const uniqueParticipantIds = new Set();
+    topicOpinions.forEach((o) => {
+      o.quotes.forEach((q) => {
+        uniqueParticipantIds.add(q.participant_id);
+      });
     });
-  });
-  return uniqueParticipantIds.size;
-}
-
-/**
- * Cleans and shapes raw predicted data for the mustache template.
- * @param {Object[]} raw - Array of predicted topic objects from predicted.json.
- * @returns {Object[]} Cleaned predicted topic objects.
- */
-function processPredicted(raw) {
-  const data = Array.isArray(raw) ? raw[0] : raw;
-  if (!data || !data.sub_contents) return { text: "", topics: [] };
-  return {
-    text: data.text,
-    topics: data.sub_contents.map((s) => ({
-      topicID: generateId(s.title || "", true),
-      title: stripMarkdownHeader(s.title),
-      text: s.text,
-      statements: (s.statements || []).map((s) => ({
-        text: s.text,
-        predictedAgreement: formatPercent(s.predicted_agreement),
-        hasPredictedAgreement: s.predicted_agreement != null,
-      })),
-    })),
-  };
-}
-
-// --- Main Execution ---
-
-// 1. Calculate aggregate statistics
-const byParticipant = groupBy(opinions, "participant_id");
-const totalParticipants = formatNumber(byParticipant.length);
-const totalParticipantsFormatted = formatNumber(byParticipant.length);
-const propositionsGenerated = 0; // Placeholder / Todo
-
-// 2. Perform transformations
-const opinionsGrouped = groupOpinions(opinions);
-const quotes = flattenQuotes(opinionsGrouped);
-const predicted = processPredicted(predictedRaw);
-
-// 3. Calculate high-level counts
-const topicsIdentified = summary.sub_contents.length;
-const topicsIdentifiedFormatted = formatNumber(topicsIdentified);
-const opinionsIdentified = opinionsGrouped
-  .map((t) => t.opinions.length)
-  .reduce((a, b) => a + b, 0);
-const opinionsIdentifiedFormatted = formatNumber(opinionsIdentified);
-
-// 4. Construct final payload (frontend-ready)
-const topics = opinionsGrouped.map((topic) => {
-  // do a draft-style sample of quotes to make sure each opinion gets some of the "top" quotes (based on our sorting by bridging score), while also maximizing the diversity of participants shown in the sample quotes across opinions
-  const allSampleQuotes = getSampleQuotes(topic.opinions);
-
-  return {
-    topicID: topic.topicID,
-    text: topic.text,
-    topicCount: topic.count,
-    topicCountFormatted: formatNumber(topic.count),
-    opinionCount: topic.opinions.length,
-    opinionCountFormatted: formatNumber(topic.opinions.length),
-    // rawQuoteCount: Sum of all quotes (including duplicates/same user)
-    rawQuoteCount: sum(topic.opinions.map((o) => o.count)),
-    // quoteCount: Unique participants
-    quoteCount: getUniqueQuoteCount(topic.opinions),
-    quoteCountFormatted: formatNumber(getUniqueQuoteCount(topic.opinions)),
-    summary: topic.summary,
-    // Map opinions to frontend structure (only sample quotes included)
-    opinions: topic.opinions.map((o) => ({
-      text: o.text,
-      count: o.count,
-      countFormatted: formatNumber(o.count),
-      quotesCountFormatted: (
-        i18n.sections?.quotesCount || "{count} Quotes"
-      ).replace("{count}", formatNumber(o.count)),
-      sampleQuotes: allSampleQuotes
-        .filter((q) => q.fullID === o.fullID)
-        .map((q) => q.text),
-      viewAllQuotes: o.quotes.length > options.sampleQuoteCount,
-      fullID: o.fullID,
-    })),
-  };
-});
-
-// Sort topics by unique quote count (most popular topics first)
-topics.sort((a, b) => b.quoteCount - a.quoteCount);
-
-// Construct participant overview data for chart of demographics
-const uniqueParticipants = byParticipant.map(([, rows]) => rows[0]);
-
-const demoKeys = Object.keys(uniqueParticipants[0] || {}).filter((k) =>
-  k.startsWith(demographics_prefix),
-);
-
-const demographics = demoKeys.map((key) => {
-  const label = key.slice(demographics_prefix.length);
-  const counts = new Map();
-  uniqueParticipants.forEach((p) => {
-    const val = p[key];
-    if (val !== undefined && val !== null && val !== "") {
-      counts.set(val, (counts.get(val) || 0) + 1);
-    }
-  });
-  let values = Array.from(counts, ([value, count]) => ({
-    value,
-    count,
-  })).sort((a, b) => b.count - a.count);
-
-  if (values.length > 6) {
-    const otherCount = values.slice(5).reduce((acc, v) => acc + v.count, 0);
-    const otherCategory = i18n.chart?.otherCategory || "Other";
-    values = [...values.slice(0, 5), { value: otherCategory, count: otherCount }];
+    return uniqueParticipantIds.size;
   }
 
-  return { label, values };
-});
+  /**
+   * Cleans and shapes raw predicted data for the mustache template.
+   * @param {Object|Object[]} raw - Predicted topic objects from predicted.json.
+   * @returns {Object} Cleaned predicted topic objects.
+   */
+  function processPredicted(raw) {
+    const data = Array.isArray(raw) ? raw[0] : raw;
+    if (!data || !data.sub_contents) return { text: "", topics: [] };
+    return {
+      text: data.text,
+      topics: data.sub_contents.map((s) => ({
+        topicID: generateId(s.title || "", true),
+        title: stripMarkdownHeader(s.title),
+        text: s.text,
+        statements: (s.statements || []).map((stmt) => ({
+          text: stmt.text,
+          predictedAgreement: formatPercent(stmt.predicted_agreement),
+          hasPredictedAgreement: stmt.predicted_agreement != null,
+        })),
+      })),
+    };
+  }
 
-demographics.sort((a, b) => a.label.localeCompare(b.label, i18n.locale));
+  // --- Main Execution ---
 
-// 7. Prepare outputs
-const executiveSummary = parseSummary(cleanMarkdown(summary.text || ""));
-const title = stripMarkdownHeader(summary.title);
+  // 1. Calculate aggregate statistics
+  const byParticipant = groupBy(opinions, "participant_id");
+  const totalParticipants = formatNumber(byParticipant.length);
+  const totalParticipantsFormatted = formatNumber(byParticipant.length);
+  const propositionsGenerated = 0; // Placeholder / Todo
 
-// Dynamic sentence interpolation
-const conversationOverviewLead = (
-  i18n.sections?.conversationLeadTemplate ||
-  "Below is a high level overview of the topics discussed in the conversation. The most discussed topics were {topTopic1} and {topTopic2}."
-)
-  .replace("{topTopic1}", topics[0]?.text || "")
-  .replace("{topTopic2}", topics[1]?.text || "");
+  // 2. Perform transformations
+  const opinionsGrouped = groupOpinions(opinions);
+  const quotes = flattenQuotes(opinionsGrouped);
+  const predicted = processPredicted(predictedRaw);
 
-const topicsIdentifiedBadge = (
-  i18n.sections?.topicsIdentifiedBadge || "{count} topics identified"
-).replace("{count}", topicsIdentifiedFormatted);
+  // 3. Calculate high-level counts
+  const topicsIdentified = summary.sub_contents.length;
+  const topicsIdentifiedFormatted = formatNumber(topicsIdentified);
+  const opinionsIdentified = opinionsGrouped
+    .map((t) => t.opinions.length)
+    .reduce((a, b) => a + b, 0);
+  const opinionsIdentifiedFormatted = formatNumber(opinionsIdentified);
 
-const baseOutput = {
-  ...options,
-  title,
-  executiveSummary,
-  conversationOverviewLead,
-  totalParticipants,
-  totalParticipantsFormatted,
-  topicsIdentified,
-  topicsIdentifiedFormatted,
-  topicsIdentifiedBadge,
-  opinionsIdentified,
-  opinionsIdentifiedFormatted,
-  propositionsGenerated,
-  topics,
-  demographics,
-  predicted,
-  hasPredicted: predicted.topics.length > 0,
-  i18n,
-};
+  // 4. Construct final payload (frontend-ready)
+  const topics = opinionsGrouped.map((topic) => {
+    // do a draft-style sample of quotes to make sure each opinion gets some of the "top" quotes (based on our sorting by bridging score), while also maximizing the diversity of participants shown in the sample quotes across opinions
+    const allSampleQuotes = getSampleQuotes(topic.opinions);
 
-// --- File Writing ---
+    return {
+      topicID: topic.topicID,
+      text: topic.text,
+      topicCount: topic.count,
+      topicCountFormatted: formatNumber(topic.count),
+      opinionCount: topic.opinions.length,
+      opinionCountFormatted: formatNumber(topic.opinions.length),
+      // rawQuoteCount: Sum of all quotes (including duplicates/same user)
+      rawQuoteCount: sum(topic.opinions.map((o) => o.count)),
+      // quoteCount: Unique participants
+      quoteCount: getUniqueQuoteCount(topic.opinions),
+      quoteCountFormatted: formatNumber(getUniqueQuoteCount(topic.opinions)),
+      summary: topic.summary,
+      // Map opinions to frontend structure (only sample quotes included)
+      opinions: topic.opinions.map((o) => ({
+        text: o.text,
+        count: o.count,
+        countFormatted: formatNumber(o.count),
+        quotesCountFormatted: (
+          i18n.sections?.quotesCount || "{count} Quotes"
+        ).replace("{count}", formatNumber(o.count)),
+        sampleQuotes: allSampleQuotes
+          .filter((q) => q.fullID === o.fullID)
+          .map((q) => q.text),
+        viewAllQuotes: o.quotes.length > options.sampleQuoteCount,
+        fullID: o.fullID,
+      })),
+    };
+  });
 
-// A. Write flat quotes file (for lazy loading in "static" mode)
-fs.writeFileSync("./temp/quotes.json", JSON.stringify(quotes));
+  // Sort topics by unique quote count (most popular topics first)
+  topics.sort((a, b) => b.quoteCount - a.quoteCount);
 
-// B. Write static data (HTML payload contains topics; quotes loaded via fetch)
-const staticOutput = { ...baseOutput };
-// Escape HTML tags to prevent XSS issues when injecting into script tags
-staticOutput.payload = JSON.stringify({
-  topics,
-  demographics,
-  options,
-  i18n,
-}).replace(/</g, "\\u003c");
-fs.writeFileSync("./temp/data-static.json", JSON.stringify(staticOutput));
+  // Construct participant overview data for chart of demographics
+  const uniqueParticipants = byParticipant.map(([, rows]) => rows[0]);
 
-// C. Write inline data (HTML payload contains topics AND all quotes)
-const inlineOutput = { ...baseOutput };
-inlineOutput.payload = JSON.stringify({
-  topics,
-  demographics,
-  options,
-  quotes,
-  i18n,
-}).replace(/</g, "\\u003c");
-fs.writeFileSync("./temp/data-inline.json", JSON.stringify(inlineOutput));
+  const demoKeys = Object.keys(uniqueParticipants[0] || {}).filter((k) =>
+    k.startsWith(demographics_prefix),
+  );
 
-console.log("Data processing complete.");
+  const demographics = demoKeys.map((key) => {
+    const label = key.slice(demographics_prefix.length);
+    const counts = new Map();
+    uniqueParticipants.forEach((p) => {
+      const val = p[key];
+      if (val !== undefined && val !== null && val !== "") {
+        counts.set(val, (counts.get(val) || 0) + 1);
+      }
+    });
+    let values = Array.from(counts, ([value, count]) => ({
+      value,
+      count,
+    })).sort((a, b) => b.count - a.count);
+
+    if (values.length > 6) {
+      const otherCount = values.slice(5).reduce((acc, v) => acc + v.count, 0);
+      const otherCategory = i18n.chart?.otherCategory || "Other";
+      values = [
+        ...values.slice(0, 5),
+        { value: otherCategory, count: otherCount },
+      ];
+    }
+
+    return { label, values };
+  });
+
+  demographics.sort((a, b) => a.label.localeCompare(b.label, i18n.locale));
+
+  // 7. Prepare outputs
+  const executiveSummary = parseSummary(cleanMarkdown(summary.text || ""));
+  const title = stripMarkdownHeader(summary.title);
+
+  // Dynamic sentence interpolation
+  const conversationOverviewLead = (
+    i18n.sections?.conversationLeadTemplate ||
+    "Below is a high level overview of the topics discussed in the conversation. The most discussed topics were {topTopic1} and {topTopic2}."
+  )
+    .replace("{topTopic1}", topics[0]?.text || "")
+    .replace("{topTopic2}", topics[1]?.text || "");
+
+  const topicsIdentifiedBadge = (
+    i18n.sections?.topicsIdentifiedBadge || "{count} topics identified"
+  ).replace("{count}", topicsIdentifiedFormatted);
+
+  const baseOutput = {
+    ...options,
+    title,
+    executiveSummary,
+    conversationOverviewLead,
+    totalParticipants,
+    totalParticipantsFormatted,
+    topicsIdentified,
+    topicsIdentifiedFormatted,
+    topicsIdentifiedBadge,
+    opinionsIdentified,
+    opinionsIdentifiedFormatted,
+    propositionsGenerated,
+    topics,
+    demographics,
+    predicted,
+    hasPredicted: predicted.topics.length > 0,
+    i18n,
+  };
+
+  // --- File Writing ---
+
+  if (!fs.existsSync(workDir)) {
+    fs.mkdirSync(workDir, { recursive: true });
+  }
+
+  // A. Write flat quotes file (for lazy loading in "static" mode)
+  fs.writeFileSync(
+    path.join(workDir, "quotes.json"),
+    JSON.stringify(quotes),
+  );
+
+  // B. Write static data (HTML payload contains topics; quotes loaded via fetch)
+  const staticOutput = { ...baseOutput };
+  // Escape HTML tags to prevent XSS issues when injecting into script tags
+  staticOutput.payload = JSON.stringify({
+    topics,
+    demographics,
+    options,
+    i18n,
+  }).replace(/</g, "\\u003c");
+  fs.writeFileSync(
+    path.join(workDir, "data-static.json"),
+    JSON.stringify(staticOutput),
+  );
+
+  // C. Write inline data (HTML payload contains topics AND all quotes)
+  const inlineOutput = { ...baseOutput };
+  inlineOutput.payload = JSON.stringify({
+    topics,
+    demographics,
+    options,
+    quotes,
+    i18n,
+  }).replace(/</g, "\\u003c");
+  fs.writeFileSync(
+    path.join(workDir, "data-inline.json"),
+    JSON.stringify(inlineOutput),
+  );
+
+  console.log("Data processing complete.");
+
+  return { dataStatic: staticOutput, dataInline: inlineOutput, quotes };
+}
+
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+
+if (isMain) {
+  // Legacy entry used by `node data.js` / build.js tasks.data — same paths as before.
+  const opinionsRaw = JSON.parse(
+    fs.readFileSync("./temp/opinions.json", "utf-8"),
+  );
+  const predictedDefault = "./input/predicted.json";
+  processReportData({
+    opinionsRaw,
+    summaryPath: "./input/summary.json",
+    configPath: "./input/config.json",
+    predictedPath: fs.existsSync(predictedDefault) ? predictedDefault : null,
+    inputDir: "./input",
+    packageRoot: ".",
+    workDir: "./temp",
+  });
+}

--- a/src/report_ui/package.json
+++ b/src/report_ui/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "dev.js",
+  "bin": {
+    "jigsaw-sensemaking-generator": "bin/cli.js"
+  },
   "scripts": {
     "predev": "node build.js dev",
     "dev": "node dev.js",


### PR DESCRIPTION
## Summary
- Make `src/report_ui` invocable with explicit input/output paths (e.g. `--bridging_scores`, `--summary`, `--output` / `--outputDir`) so pipelines can build reports without copying artefacts into `input/`.
- Preserve the existing copy-into-`input/` workflow, default output layout (`output/static`, `output/inline`), `dev` / `preview` / `github` tasks, and the zero-install `npx`-based build steps.
- Document the optional CLI flags additively in `src/report_ui/README.md` and briefly in the root README Step 6.

## Test plan
- [x] Legacy: copy fixtures into `input/`, run `npm run inline` → `output/inline/index.html`
- [x] Explicit: `node build.js inline --bridging_scores … --summary … --output …/new_report_build.html`
- [x] Confirmed legacy and explicit inline HTML are byte-identical on the same fixtures
- [x] `npm run static` still writes `output/static/index.html` + `quotes.json`
- [x] Explicit-path build does not wipe the default `output/` tree
- [x] Optional: smoke `npm run dev` / `npm run preview` locally